### PR TITLE
fix: Re-apply fix to avoid tagging S3 bucket objects since they are restricted to 10 tags and they are not actively used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@7.0.0
+  architect: giantswarm/architect@9.5.5
 
 workflows:
   build-workflow:
@@ -49,10 +49,6 @@ jobs:
     steps:
       - checkout
       - architect/image-prepare-tag
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .docker_image_tag
 
   build-and-push:
     machine:
@@ -67,7 +63,7 @@ jobs:
             REGISTRY_SERVER=gsoci.azurecr.io
             REGISTRY=${REGISTRY_SERVER}/giantswarm
             echo "$ACR_GSOCI_PASSWORD" | docker login --username $ACR_GSOCI_USERNAME --password-stdin ${REGISTRY_SERVER}
-            TAG=$(cat .docker_image_tag)
+            TAG=$(cat .build_version)
 
             curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid tagging S3 bucket objects since they are restricted to 10 tags and they are not actively used (this fix got lost in the Helm packaging migration, re-applying the fix now)
+
 ## [0.3.0] - 2026-05-05
 
 ### Added

--- a/helm/crossplane-fn-irsa/templates/composition.yaml
+++ b/helm/crossplane-fn-irsa/templates/composition.yaml
@@ -145,7 +145,7 @@ spec:
                       region         = region
                       contentBase64  = s3_discovery_content
                       sourceHash     = crypto.md5(s3_discovery_content)
-                      tags           = _tags
+                      tags           = {}
                   }
               }
           }
@@ -165,7 +165,7 @@ spec:
                       region         = region
                       contentBase64  = s3_key_content
                       sourceHash     = crypto.md5(s3_key_content)
-                      tags           = _tags
+                      tags           = {}
                   }
               }
           }


### PR DESCRIPTION
Same as #30 which got lost in the Helm packaging change